### PR TITLE
Grammatical fix "barely" -> "almost"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ More docs can be found on http://www.steamdev.com/zclip/
 
 I wrote a tutorial about jQuery Clipboard at https://waaave.com/tutorial/jquery/copy-text-to-clipboard-using-jquery/
 
-jQuery Clipboard is mostly based on jQuery.zClip, the plugin APIs remain barely the same.
+jQuery Clipboard is mostly based on jQuery.zClip, the plugin APIs remain almost the same.


### PR DESCRIPTION
"Barely" would mean the APIs are not similar. "Almost" would mean they are very similar.
